### PR TITLE
Added support for notes for tribe favor and displaying them on the selection board

### DIFF
--- a/AncestorQol.cs
+++ b/AncestorQol.cs
@@ -47,37 +47,22 @@ public class AncestorQol : BaseSettingsPlugin<AncestorQolSettings>
                     var tribeFavourReward = option.GetChildFromIndices(3, 0)?.Children ?? new List<Element>();
                     foreach (var tribe in tribeFavourReward)
                     {
-                        var tooltip = tribe[0]?.Tooltip?.Text;
-                        var tier = Settings.GetTribeShopTier(tooltip);
-                        var favorNote = Settings.FavorNotes.GetValueOrDefault(tooltip ?? string.Empty);
+                        var favorTribeName = tribe[0]?.Tooltip?.Text;
+                        var tier = Settings.GetTribeShopTier(favorTribeName);
                         var color = TierToColor(tier);
                         var rect = tribe.GetClientRectCache;
                         rect.Inflate(-5, 0);
                         if (!rect.Intersects(containerRect)) continue;
                         Graphics.DrawFrame(rect, color, Settings.FrameThickness);
 
+                        var favorNote = Settings.FavorNotes.GetValueOrDefault(favorTribeName ?? string.Empty);
                         if (!string.IsNullOrEmpty(favorNote))
                         {
-                            var favorNoteRect = rect;
-                            favorNoteRect.Height = 30; // Adjust the height of the box as needed
-                            favorNoteRect.X = rect.Left; // Place it at the left of the tribe rectangle
-                            favorNoteRect.Y = rect.Bottom - favorNoteRect.Height; // Place it at the bottom
-
-                            var boxVerticalOffset = -30; // You can adjust this value as needed
-                            favorNoteRect.Y -= boxVerticalOffset;
-
-                            //The above works for 4k, but for other resolutions needs to be converted to relative screen size units, or a ui element
-                            //needs to be added to adjust these on a fixed slider if they are gonna be a fixed value.
-
-                            Graphics.DrawBox(favorNoteRect, Color.Black);
-
-                            // Calculate text position to center it within the black box
                             var textSize = Graphics.MeasureText(favorNote);
-                            var textPosition = new Vector2(
-                                favorNoteRect.Left + (favorNoteRect.Width - textSize.X) / 2,
-                                favorNoteRect.Top + (favorNoteRect.Height - textSize.Y) / 2);
-
-                            Graphics.DrawText(favorNote, textPosition, Color.White);
+                            var textOffset = new Vector2((rect.Width - textSize.X) / 2, 0);
+                            var textPos = rect.BottomLeft.ToVector2Num() + textOffset;
+                            Graphics.DrawBox(rect.BottomLeft.ToVector2Num(), rect.BottomRight.ToVector2Num() + new Vector2(0, textSize.Y), Color.Black);
+                            Graphics.DrawText(favorNote, textPos, Color.White);
                         }
                     }
                 }
@@ -124,9 +109,9 @@ public class AncestorQol : BaseSettingsPlugin<AncestorQolSettings>
                     Graphics.DrawText(tooltipDescription, topRight + new Vector2(textPadding), Color.White);
                     if (!string.IsNullOrEmpty(unitNote))
                     {
-                        var noteRect = option[2]?.GetClientRectCache ?? default;
-                        Graphics.DrawBox(noteRect, Color.Black);
-                        Graphics.DrawText(unitNote, noteRect.TopLeft.ToVector2Num());
+                        var unitNoteRect = option[2]?.GetClientRectCache ?? default;
+                        Graphics.DrawBox(unitNoteRect, Color.Black);
+                        Graphics.DrawText(unitNote, unitNoteRect.TopLeft.ToVector2Num());
                     }
                 }
                 catch (Exception ex)
@@ -152,9 +137,9 @@ public class AncestorQol : BaseSettingsPlugin<AncestorQolSettings>
                     Graphics.DrawFrame(optionRect, color, Settings.FrameThickness);
                     if (!string.IsNullOrEmpty(unitNote))
                     {
-                        var noteRect = option[2]?.GetClientRectCache ?? default;
-                        Graphics.DrawBox(noteRect, Color.Black);
-                        Graphics.DrawText(unitNote, noteRect.TopLeft.ToVector2Num());
+                        var unitNoteRect = option[2]?.GetClientRectCache ?? default;
+                        Graphics.DrawBox(unitNoteRect, Color.Black);
+                        Graphics.DrawText(unitNote, unitNoteRect.TopLeft.ToVector2Num());
                     }
                 }
                 catch (Exception ex)

--- a/AncestorQol.cs
+++ b/AncestorQol.cs
@@ -49,11 +49,36 @@ public class AncestorQol : BaseSettingsPlugin<AncestorQolSettings>
                     {
                         var tooltip = tribe[0]?.Tooltip?.Text;
                         var tier = Settings.GetTribeShopTier(tooltip);
+                        var favorNote = Settings.FavorNotes.GetValueOrDefault(tooltip ?? string.Empty);
                         var color = TierToColor(tier);
                         var rect = tribe.GetClientRectCache;
                         rect.Inflate(-5, 0);
                         if (!rect.Intersects(containerRect)) continue;
                         Graphics.DrawFrame(rect, color, Settings.FrameThickness);
+
+                        if (!string.IsNullOrEmpty(favorNote))
+                        {
+                            var favorNoteRect = rect;
+                            favorNoteRect.Height = 30; // Adjust the height of the box as needed
+                            favorNoteRect.X = rect.Left; // Place it at the left of the tribe rectangle
+                            favorNoteRect.Y = rect.Bottom - favorNoteRect.Height; // Place it at the bottom
+
+                            var boxVerticalOffset = -30; // You can adjust this value as needed
+                            favorNoteRect.Y -= boxVerticalOffset;
+
+                            //The above works for 4k, but for other resolutions needs to be converted to relative screen size units, or a ui element
+                            //needs to be added to adjust these on a fixed slider if they are gonna be a fixed value.
+
+                            Graphics.DrawBox(favorNoteRect, Color.Black);
+
+                            // Calculate text position to center it within the black box
+                            var textSize = Graphics.MeasureText(favorNote);
+                            var textPosition = new Vector2(
+                                favorNoteRect.Left + (favorNoteRect.Width - textSize.X) / 2,
+                                favorNoteRect.Top + (favorNoteRect.Height - textSize.Y) / 2);
+
+                            Graphics.DrawText(favorNote, textPosition, Color.White);
+                        }
                     }
                 }
                 catch (Exception ex)
@@ -76,7 +101,7 @@ public class AncestorQol : BaseSettingsPlugin<AncestorQolSettings>
                     var unit = option.Unit;
                     var item = option.Item;
                     var tier = Settings.GetUnitTier(unit?.Id ?? item?.Id ?? string.Empty);
-                    var note = Settings.UnitNotes.GetValueOrDefault(unit?.Id ?? item?.Id ?? string.Empty);
+                    var unitNote = Settings.UnitNotes.GetValueOrDefault(unit?.Id ?? item?.Id ?? string.Empty);
                     var color = TierToColor(tier);
                     var tooltipDescription = (unit, item) switch
                     {
@@ -97,11 +122,11 @@ public class AncestorQol : BaseSettingsPlugin<AncestorQolSettings>
                     Graphics.DrawBox(topRight, topRight + rect, Color.Black);
                     Graphics.DrawFrame(topRight, topRight + rect, color, Settings.FrameThickness);
                     Graphics.DrawText(tooltipDescription, topRight + new Vector2(textPadding), Color.White);
-                    if (!string.IsNullOrEmpty(note))
+                    if (!string.IsNullOrEmpty(unitNote))
                     {
                         var noteRect = option[2]?.GetClientRectCache ?? default;
                         Graphics.DrawBox(noteRect, Color.Black);
-                        Graphics.DrawText(note, noteRect.TopLeft.ToVector2Num());
+                        Graphics.DrawText(unitNote, noteRect.TopLeft.ToVector2Num());
                     }
                 }
                 catch (Exception ex)
@@ -120,16 +145,16 @@ public class AncestorQol : BaseSettingsPlugin<AncestorQolSettings>
                     var unit = option.Unit;
                     var item = option.Item;
                     var tier = Settings.GetUnitTier(unit?.Id ?? item?.Id ?? string.Empty);
-                    var note = Settings.UnitNotes.GetValueOrDefault(unit?.Id ?? item?.Id ?? string.Empty);
+                    var unitNote = Settings.UnitNotes.GetValueOrDefault(unit?.Id ?? item?.Id ?? string.Empty);
                     var color = TierToColor(tier);
 
                     var optionRect = option.GetClientRectCache;
                     Graphics.DrawFrame(optionRect, color, Settings.FrameThickness);
-                    if (!string.IsNullOrEmpty(note))
+                    if (!string.IsNullOrEmpty(unitNote))
                     {
                         var noteRect = option[2]?.GetClientRectCache ?? default;
                         Graphics.DrawBox(noteRect, Color.Black);
-                        Graphics.DrawText(note, noteRect.TopLeft.ToVector2Num());
+                        Graphics.DrawText(unitNote, noteRect.TopLeft.ToVector2Num());
                     }
                 }
                 catch (Exception ex)

--- a/AncestorQol.cs
+++ b/AncestorQol.cs
@@ -147,6 +147,8 @@ public class AncestorQol : BaseSettingsPlugin<AncestorQolSettings>
             1 => Settings.Tier1Color.Value,
             2 => Settings.Tier2Color.Value,
             3 => Settings.Tier3Color.Value,
+            4 => Settings.Tier4Color.Value,
+            5 => Settings.Tier5Color.Value,
             _ => Color.Pink
         };
     }

--- a/AncestorQolSettings.cs
+++ b/AncestorQolSettings.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Drawing.Imaging;
 using System.Linq;
 using ExileCore.Shared.Interfaces;
 using ExileCore.Shared.Nodes;

--- a/AncestorQolSettings.cs
+++ b/AncestorQolSettings.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Drawing.Imaging;
 using System.Linq;
 using ExileCore.Shared.Interfaces;
 using ExileCore.Shared.Nodes;
@@ -176,7 +177,7 @@ public class AncestorQolSettings : ISettings
                             ImGui.TableNextColumn();
                             ImGui.SetNextItemWidth(300);
                             var currentValue = GetUnitTier(id);
-                            if (ImGui.SliderInt($"{name}###{id}", ref currentValue, 1, 3))
+                            if (ImGui.SliderInt($"{name}###{id}", ref currentValue, 1, 5))
                             {
                                 UnitTiers[id] = currentValue;
                             }
@@ -224,7 +225,7 @@ public class AncestorQolSettings : ISettings
                             ImGui.TableNextColumn();
                             ImGui.SetNextItemWidth(300);
                             var shopTier = GetTribeShopTier(tribe);
-                            if (ImGui.SliderInt($"{tribe} shop", ref shopTier, 1, 3))
+                            if (ImGui.SliderInt($"{tribe} shop", ref shopTier, 1, 5))
                             {
                                 TribeShopTiers[tribe] = shopTier;
                             }
@@ -233,7 +234,7 @@ public class AncestorQolSettings : ISettings
                             ImGui.SetNextItemWidth(300);
 
                             var rewardTier = GetTribeRewardTier(tribe);
-                            if (ImGui.SliderInt($"{tribe} reward", ref rewardTier, 1, 3))
+                            if (ImGui.SliderInt($"{tribe} reward", ref rewardTier, 1, 5))
                             {
                                 TribeRewardTiers[tribe] = rewardTier;
                             }
@@ -253,26 +254,29 @@ public class AncestorQolSettings : ISettings
 
     public int GetUnitTier(string type)
     {
-        return UnitTiers.GetValueOrDefault(type ?? "", 2);
+        return UnitTiers.GetValueOrDefault(type ?? "", 3);
     }
 
     public int GetTribeShopTier(string tribeName)
     {
-        return TribeShopTiers.GetValueOrDefault(tribeName ?? "", 2);
+        return TribeShopTiers.GetValueOrDefault(tribeName ?? "", 3);
     }
 
     public int GetTribeRewardTier(string tribeName)
     {
-        return TribeRewardTiers.GetValueOrDefault(tribeName ?? "", 2);
+        return TribeRewardTiers.GetValueOrDefault(tribeName ?? "", 3);
     }
 
     public ToggleNode Enable { get; set; } = new ToggleNode(false);
 
     public RangeNode<int> FrameThickness { get; set; } = new RangeNode<int>(2, 0, 10);
 
-    public ColorNode Tier1Color { get; set; } = new(Color.Green);
-    public ColorNode Tier2Color { get; set; } = new(Color.White);
-    public ColorNode Tier3Color { get; set; } = new(Color.Red);
+    public ColorNode Tier1Color { get; set; } = new(Color.Purple);
+    public ColorNode Tier2Color { get; set; } = new(Color.Green);
+    public ColorNode Tier3Color { get; set; } = new(Color.White);
+    public ColorNode Tier4Color { get; set; } = new(Color.Yellow);
+    public ColorNode Tier5Color { get; set; } = new(Color.Red);
+
 
     [JsonIgnore]
     public CustomNode Units { get; }
@@ -295,15 +299,15 @@ public class AncestorQolSettings : ISettings
 
     public Dictionary<string, int> TribeRewardTiers = new()
     {
-        ["Ngamahu Tribe"] = 1,
-        ["Tawhoa Tribe"] = 1,
-        ["Ramako Tribe"] = 1,
-        ["Arohongui Tribe"] = 1,
-        ["Tasalio Tribe"] = 1,
-        ["Valako Tribe"] = 3,
-        ["Hinekora Tribe"] = 3,
-        ["Kitava Tribe"] = 3,
-        ["Tukohama Tribe"] = 3,
-        ["Rongokurai Tribe"] = 3,
+        ["Ngamahu Tribe"] = 2,
+        ["Tawhoa Tribe"] = 2,
+        ["Ramako Tribe"] = 2,
+        ["Arohongui Tribe"] = 2,
+        ["Tasalio Tribe"] = 2,
+        ["Valako Tribe"] = 5,
+        ["Hinekora Tribe"] = 5,
+        ["Kitava Tribe"] = 5,
+        ["Tukohama Tribe"] = 5,
+        ["Rongokurai Tribe"] = 5,
     };
 }

--- a/AncestorQolSettings.cs
+++ b/AncestorQolSettings.cs
@@ -157,15 +157,15 @@ public class AncestorQolSettings : ISettings
         {
             DrawDelegate = () =>
             {
-                if (ImGui.TreeNode("Unit tiers"))
+                if (ImGui.TreeNode("Unit & Item Tiers"))
                 {
                     ImGui.InputTextWithHint("##UnitFilter", "Filter", ref unitFilter, 100);
 
                     if (ImGui.BeginTable("UnitConfig", 4, ImGuiTableFlags.SizingFixedFit | ImGuiTableFlags.Borders))
                     {
-                        ImGui.TableSetupColumn("Name");
-                        ImGui.TableSetupColumn("Tier", ImGuiTableColumnFlags.WidthFixed, 300);
-                        ImGui.TableSetupColumn("Note", ImGuiTableColumnFlags.WidthFixed, 300);
+                        ImGui.TableSetupColumn("Unit & Item Name");
+                        ImGui.TableSetupColumn("Unit & Item Tier", ImGuiTableColumnFlags.WidthFixed, 300);
+                        ImGui.TableSetupColumn("Unit & Item Notes", ImGuiTableColumnFlags.WidthFixed, 300);
                         ImGui.TableHeadersRow();
                         foreach (var (id, name) in UnitTypes.Where(t => t.Name.Contains(unitFilter, StringComparison.InvariantCultureIgnoreCase)))
                         {
@@ -184,10 +184,10 @@ public class AncestorQolSettings : ISettings
                             ImGui.TableNextColumn();
                             ImGui.SetNextItemWidth(300);
 
-                            var note = UnitNotes.GetValueOrDefault(id) ?? string.Empty;
-                            if (ImGui.InputText("note", ref note, 200))
+                            var unitNote = UnitNotes.GetValueOrDefault(id) ?? string.Empty;
+                            if (ImGui.InputText(" unit & item note", ref unitNote, 200))
                             {
-                                UnitNotes[id] = note;
+                                UnitNotes[id] = unitNote;
                             }
 
                             ImGui.PopID();
@@ -205,15 +205,16 @@ public class AncestorQolSettings : ISettings
         {
             DrawDelegate = () =>
             {
-                if (ImGui.TreeNode("Tribe tiers"))
+                if (ImGui.TreeNode("Tribe Tiers"))
                 {
                     ImGui.InputTextWithHint("##TribeFilter", "Filter", ref tribeFilter, 100);
 
                     if (ImGui.BeginTable("TribeConfig", 4, ImGuiTableFlags.SizingFixedFit | ImGuiTableFlags.Borders))
                     {
-                        ImGui.TableSetupColumn("Name");
-                        ImGui.TableSetupColumn("Shop tier", ImGuiTableColumnFlags.WidthFixed, 300);
-                        ImGui.TableSetupColumn("Reward tier", ImGuiTableColumnFlags.WidthFixed, 300);
+                        ImGui.TableSetupColumn("Tribe Name");
+                        ImGui.TableSetupColumn("Favor Reward Tier", ImGuiTableColumnFlags.WidthFixed, 300);
+                        ImGui.TableSetupColumn("Reward Opertunity Tier", ImGuiTableColumnFlags.WidthFixed, 300);
+                        ImGui.TableSetupColumn("Favor Reward Tier Notes", ImGuiTableColumnFlags.WidthFixed, 300);
                         ImGui.TableHeadersRow();
                         foreach (var tribe in TribeNames.Where(t => t.Contains(tribeFilter, StringComparison.InvariantCultureIgnoreCase)))
                         {
@@ -224,7 +225,7 @@ public class AncestorQolSettings : ISettings
                             ImGui.TableNextColumn();
                             ImGui.SetNextItemWidth(300);
                             var shopTier = GetTribeShopTier(tribe);
-                            if (ImGui.SliderInt($"{tribe} shop", ref shopTier, 1, 5))
+                            if (ImGui.SliderInt($"{tribe} favor", ref shopTier, 1, 5))
                             {
                                 TribeShopTiers[tribe] = shopTier;
                             }
@@ -236,6 +237,15 @@ public class AncestorQolSettings : ISettings
                             if (ImGui.SliderInt($"{tribe} reward", ref rewardTier, 1, 5))
                             {
                                 TribeRewardTiers[tribe] = rewardTier;
+                            }
+
+                            ImGui.TableNextColumn();
+                            ImGui.SetNextItemWidth(300);
+
+                            var favorNote = FavorNotes.GetValueOrDefault(tribe) ?? string.Empty; // this bit here
+                            if (ImGui.InputText($"{tribe} favor note", ref favorNote, 200))
+                            {
+                                FavorNotes[tribe] = favorNote;
                             }
 
                             ImGui.PopID();
@@ -289,6 +299,10 @@ public class AncestorQolSettings : ISettings
     };
 
     public Dictionary<string, string> UnitNotes = new()
+    {
+    };
+
+    public Dictionary<string, string> FavorNotes = new()
     {
     };
 

--- a/AncestorQolSettings.cs
+++ b/AncestorQolSettings.cs
@@ -185,7 +185,7 @@ public class AncestorQolSettings : ISettings
                             ImGui.SetNextItemWidth(300);
 
                             var unitNote = UnitNotes.GetValueOrDefault(id) ?? string.Empty;
-                            if (ImGui.InputText(" unit & item note", ref unitNote, 200))
+                            if (ImGui.InputText("unit & item note", ref unitNote, 200))
                             {
                                 UnitNotes[id] = unitNote;
                             }


### PR DESCRIPTION
Added initial support for Tribe favor reward notes and to display them on the main ToTA board. Currently using fixed values for size and offset to draw the text box. Either dynamic relative values to the game window size should be used or a set of sliders for size and offset of said box should be added for these values so that they can work across all resolutions correctly without having to adjust the hard coded values. Check the code source comments for more details.